### PR TITLE
Configurable offset and size for loaded file

### DIFF
--- a/hw/avatar/arm_helper.c
+++ b/hw/avatar/arm_helper.c
@@ -128,5 +128,5 @@ static int banked_gdb_get_reg(CPUARMState *env, uint8_t *buf, int reg)
 void avatar_add_banked_registers(ARMCPU *cpu){
     CPUState *cs = CPU(cpu);
     gdb_register_coprocessor(cs, banked_gdb_get_reg, banked_gdb_set_reg,
-            21, "arm-banked.xml", 0);
+            22, "arm-banked.xml", 0);
 }

--- a/hw/avatar/configurable_machine.c
+++ b/hw/avatar/configurable_machine.c
@@ -285,6 +285,7 @@ static void init_memory_area(QDict *mapping, const char *kernel_filename)
         const char * filename;
         int dirname_len = get_dirname_len(kernel_filename);
         ssize_t err;
+        uint64_t file_offset = 0;
 
         g_assert(qobject_type(qdict_get(mapping, "file")) == QTYPE_QSTRING);
         filename = qdict_get_str(mapping, "file");
@@ -307,7 +308,26 @@ static void init_memory_area(QDict *mapping, const char *kernel_filename)
             data_size = get_file_size(filename);
         }
 
-        printf("Configurable: Inserting %"
+        if (qdict_haskey(mapping, "file_offset")) {
+          off_t sbytes;
+          g_assert(qobject_type(qdict_get(mapping, "file_offset")) == QTYPE_QINT);
+          file_offset = qdict_get_int(mapping, "file_offset");
+          sbytes = lseek(file,file_offset,SEEK_SET);
+          g_assert(sbytes > 0);
+          data_size -= sbytes;
+
+        }
+
+        if (qdict_haskey(mapping,"file_bytes")) {
+          ssize_t file_bytes;
+          g_assert(qobject_type(qdict_get(mapping, "file_bytes")) == QTYPE_QINT);
+          file_bytes = qdict_get_int(mapping, "file_bytes");
+          data_size = file_bytes;
+          printf("File bytes: 0x%lx\n",data_size);
+
+        }
+
+        printf("Configurable: Inserting 0x%"
                PRIx64 " bytes of data in memory region %s\n", data_size, name);
         //Size of data to put into a RAM region needs to fit in the RAM region
         g_assert(data_size <= size);
@@ -322,8 +342,9 @@ static void init_memory_area(QDict *mapping, const char *kernel_filename)
 
         //And copy the data to the memory, if it is initialized
         printf("Configurable: Copying 0x%" PRIx64
-               " byte of data from file %s to address 0x%" PRIx64
-               "\n", data_size, filename, address);
+               " byte of data from file %s beginning at offset 0x%" PRIx64
+               " to address 0x%" PRIx64
+               "\n", data_size, filename, file_offset,address);
         cpu_physical_memory_write_rom(&address_space_memory,
                                       address, (uint8_t *) data, data_size);
         g_free(data);


### PR DESCRIPTION
This allows to specify a "file_offset" and "file_bytes" to load only parts of a binary into memory.
If "file_bytes" is not provided, the entire file beginning from "file_offset" is loaded.