### PR TITLE
Configurable Machine for MIPS, i386, X86_64

### DIFF
--- a/hw/avatar/Makefile.objs
+++ b/hw/avatar/Makefile.objs
@@ -1,3 +1,5 @@
 obj-$(TARGET_ARM)  += avatar_posix.o configurable_machine.o remote_memory.o arm_helper.o
 obj-$(TARGET_MIPS) += avatar_posix.o configurable_machine.o remote_memory.o
+obj-$(TARGET_I386) += configurable_machine.o
+obj-$(TARGET_X86_64) += configurable_machine.o
 obj-$(CONFIG_SOFTMMU) += interrupts.o

--- a/hw/avatar/interrupts.c
+++ b/hw/avatar/interrupts.c
@@ -11,6 +11,7 @@
 
 #ifdef TARGET_ARM
 #include "target/arm/cpu.h"
+
 #elif defined(TARGET_MIPS)
 #include "target/mips/cpu.h"
 #endif
@@ -20,26 +21,36 @@
 #include "hw/avatar/remote_memory.h"
 
 
-static QemuAvatarMessageQueue *irq_rx_queue_ref = NULL;
-static QemuAvatarMessageQueue *irq_tx_queue_ref = NULL;
-
 extern  QemuAvatarMessageQueue *rmem_rx_queue_ref;
 extern  QemuAvatarMessageQueue *rmem_tx_queue_ref;
 
+/* Common declarations,
+ * for now, only ARM target is implemented 
+ */
+#ifdef TARGET_ARM
+
+static QemuAvatarMessageQueue *irq_rx_queue_ref = NULL;
+static QemuAvatarMessageQueue *irq_tx_queue_ref = NULL;
+
 static uint64_t req_id;
-
-static bool armv7m_exception_handling_enabled = false;
 static uint8_t ignore_irq_return_map[32] = {0};
+#endif
+
+/* Architecture specific declaration */
+#ifdef TARGET_ARM
+static bool armv7m_exception_handling_enabled = false;
+#endif
 
 
+#ifdef TARGET_ARM
 void qmp_avatar_armv7m_set_vector_table_base(int64_t num_cpu, int64_t base, Error **errp)
 {
-#ifdef TARGET_ARM
+//#ifdef TARGET_ARM
     qemu_log_mask(LOG_AVATAR, "Changing NVIC base to%lx\n", base & 0xffffff80);
     ARMCPU *armcpu = ARM_CPU(qemu_get_cpu(num_cpu));
     /* MM: qemu now has multiple vecbases, we may need to fix this */
     armcpu->env.v7m.vecbase[armcpu->env.v7m.secure] = base & 0xffffff80;
-#endif
+//#endif
 }
 
 
@@ -120,13 +131,13 @@ void qmp_avatar_armv7m_unignore_irq_return(int64_t num_irq, Error **errp)
 
 void qmp_avatar_armv7m_inject_irq(int64_t num_cpu,int64_t num_irq, Error **errp)
 {
-#ifdef TARGET_ARM
+//#ifdef TARGET_ARM
     qemu_log_mask(LOG_AVATAR, "Injecting exception 0x%lx\n", num_irq);
     ARMCPU *armcpu = ARM_CPU(qemu_get_cpu(num_cpu));
     CPUARMState *env = &armcpu->env;
     /*  MM: for now, we can only inject non-secure irqs */
     armv7m_nvic_set_pending(env->nvic, num_irq, false);
-#endif
+//#endif
 }
 
 
@@ -177,4 +188,5 @@ void avatar_armv7m_exception_enter(int irq)
         }
     }
 }
+#endif
 

--- a/qapi/Makefile.objs
+++ b/qapi/Makefile.objs
@@ -9,8 +9,8 @@ QAPI_COMMON_MODULES = audio authz block-core block char common control crypto
 QAPI_COMMON_MODULES += dump error introspect job machine migration misc
 QAPI_COMMON_MODULES += net pragma qdev qom rdma rocker run-state sockets tpm
 QAPI_COMMON_MODULES += trace transaction ui
-QAPI_COMMON_MODULES += avatar
 QAPI_TARGET_MODULES = machine-target misc-target
+QAPI_TARGET_MODULES += avatar
 QAPI_MODULES = $(QAPI_COMMON_MODULES) $(QAPI_TARGET_MODULES)
 
 util-obj-y += qapi-builtin-types.o

--- a/qapi/avatar.json
+++ b/qapi/avatar.json
@@ -15,7 +15,8 @@
   'data': {
       'irq_rx_queue_name': 'str', 'irq_tx_queue_name': 'str',
       'rmem_rx_queue_name': 'str', 'rmem_tx_queue_name': 'str'
-  }
+  },
+  'if': 'defined(TARGET_ARM)'
 }
 
 ##
@@ -25,7 +26,9 @@
 #
 # avatar-qemu only
 ##
-{ 'command': 'avatar-armv7m-disable-irq' }
+{ 'command': 'avatar-armv7m-disable-irq',
+  'if': 'defined(TARGET_ARM)'
+}
 
 ##
 # @avatar-armv7m-inject-irq:
@@ -35,7 +38,8 @@
 # avatar-qemu only
 ##
 { 'command': 'avatar-armv7m-inject-irq',
-  'data': {'num_cpu': 'int', 'num_irq': 'int' }
+  'data': {'num_cpu': 'int', 'num_irq': 'int' },
+  'if': 'defined(TARGET_ARM)'
 }
 
 ##
@@ -46,7 +50,8 @@
 # avatar-qemu only
 ##
 { 'command': 'avatar-armv7m-ignore-irq-return',
-  'data': {'num_irq': 'int' }
+  'data': {'num_irq': 'int' },
+  'if': 'defined(TARGET_ARM)'
 }
 
 
@@ -58,7 +63,8 @@
 # avatar-qemu only
 ##
 { 'command': 'avatar-armv7m-unignore-irq-return',
-  'data': {'num_irq': 'int' }
+  'data': {'num_irq': 'int' },
+  'if': 'defined(TARGET_ARM)'
 }
 
 ##
@@ -69,7 +75,8 @@
 # avatar-qemu only
 ##
 { 'command': 'avatar-armv7m-set-vector-table-base',
-  'data': {'num_cpu': 'int', 'base': 'int' }
+  'data': {'num_cpu': 'int', 'base': 'int' },
+  'if': 'defined(TARGET_ARM)'
 }
 
 

--- a/target/i386/cpu.c
+++ b/target/i386/cpu.c
@@ -61,6 +61,12 @@
 
 #include "disas/capstone.h"
 
+/* Configurable machine */
+static int x86_configurable_machine_mode = 0;
+void set_x86_configurable_machine(int mode) {
+    x86_configurable_machine_mode = mode;
+}
+
 /* Helpers for building CPUID[2] descriptors: */
 
 struct CPUID2CacheDescriptorInfo {
@@ -6017,7 +6023,18 @@ static void x86_cpu_reset(DeviceState *dev)
     env->tr.limit = 0xffff;
     env->tr.flags = DESC_P_MASK | (11 << DESC_TYPE_SHIFT);
 
-    cpu_x86_load_seg_cache(env, R_CS, 0xf000, 0xffff0000, 0xffff,
+
+    // Default values for starting a system in real mode
+    unsigned int cs_selector = 0xf000;
+    target_ulong cs_base = 0xffff0000;
+
+    if (x86_configurable_machine_mode != 0) {
+      // For x86 configurable machine, we don't want to start in real mode
+      cs_selector = 0;
+      cs_base = 0;
+    }
+
+    cpu_x86_load_seg_cache(env, R_CS, cs_selector, cs_base, 0xffff,
                            DESC_P_MASK | DESC_S_MASK | DESC_CS_MASK |
                            DESC_R_MASK | DESC_A_MASK);
     cpu_x86_load_seg_cache(env, R_DS, 0, 0, 0xffff,
@@ -6036,10 +6053,27 @@ static void x86_cpu_reset(DeviceState *dev)
                            DESC_P_MASK | DESC_S_MASK | DESC_W_MASK |
                            DESC_A_MASK);
 
+    if (x86_configurable_machine_mode == 32) {
+      // For configurable machine, don't continue
+      // setting up initial state. These registers
+      // values should all be 0 or undefined at the start
+      // of a unicorn-style execution
+
+      // But do set hflags so we're in 32-bit mode (else we end up in 16-bit)
+      env->hflags |= HF_CS32_MASK;
+      return;
+    }else if (x86_configurable_machine_mode == 64) {
+      // Set hflags so we're in 64-bit mode (else we end up in 16-bit)
+      env->hflags |= HF_CS64_MASK;
+      return;
+    }
+
+
     env->eip = 0xfff0;
     env->regs[R_EDX] = env->cpuid_version;
 
     env->eflags = 0x2;
+
 
     /* FPU init */
     for (i = 0; i < 8; i++) {

--- a/target/i386/cpu.h
+++ b/target/i386/cpu.h
@@ -1912,6 +1912,7 @@ int cpu_x86_signal_handler(int host_signum, void *pinfo,
                            void *puc);
 
 /* cpu.c */
+void set_x86_configurable_machine(int mode);
 void cpu_x86_cpuid(CPUX86State *env, uint32_t index, uint32_t count,
                    uint32_t *eax, uint32_t *ebx,
                    uint32_t *ecx, uint32_t *edx);

--- a/target/mips/cpu.h
+++ b/target/mips/cpu.h
@@ -1164,7 +1164,7 @@ struct MIPSCPU {
 
 
 void mips_cpu_list(void);
-MIPSCPU *cpu_mips_init(const char *cpu_model);
+
 #define cpu_signal_handler cpu_mips_signal_handler
 #define cpu_list mips_cpu_list
 

--- a/target/mips/translate.c
+++ b/target/mips/translate.c
@@ -31324,31 +31324,6 @@ void mips_tcg_init(void)
 
 #include "translate_init.inc.c"
 
-MIPSCPU *cpu_mips_init(const char *cpu_model)
-{
-    MIPSCPU *cpu;
-    CPUMIPSState *env;
-    const mips_def_t *def;
-
-    def = cpu_mips_find_by_name(cpu_model);
-    if (!def)
-        return NULL;
-    cpu = MIPS_CPU(object_new(TYPE_MIPS_CPU));
-    env = &cpu->env;
-    env->cpu_model = def;
-    env->exception_base = (int32_t)0xBFC00000;
-
-#ifndef CONFIG_USER_ONLY
-    mmu_init(env, def);
-#endif
-    fpu_init(env, def);
-    mvp_init(env, def);
-
-      object_property_set_bool(OBJECT(cpu), "realized", true, NULL);
-
-    return cpu;
-}
-
 void cpu_mips_realize_env(CPUMIPSState *env)
 {
     env->exception_base = (int32_t)0xBFC00000;

--- a/target/mips/translate_init.inc.c
+++ b/target/mips/translate_init.inc.c
@@ -922,18 +922,6 @@ const mips_def_t mips_defs[] =
 };
 const int mips_defs_number = ARRAY_SIZE(mips_defs);
 
-static const mips_def_t *cpu_mips_find_by_name (const char *name)
-{
-    int i;
-
-    for (i = 0; i < ARRAY_SIZE(mips_defs); i++) {
-        if (strcasecmp(name, mips_defs[i].name) == 0) {
-            return &mips_defs[i];
-        }
-    }
-    return NULL;
-}
-
 void mips_cpu_list(void)
 {
     int i;


### PR DESCRIPTION
Port of configurable-machine features from [PANDA](https://github.com/panda-re/panda), updated to hopefully work with QEMU 5.1.

Note that although this PR contains a configurable mcahine for the i386 and x86_64-softmmu targets, those don't currently build in avatar-qemu. It's probably a simple missing `#ifdef target_xxx` guard, but I'm not too familiar with the codebase:
```
  LINK    i386-softmmu/qemu-system-i386
hw/avatar/interrupts.o: In function `avatar_armv7m_nvic_forward_write':
/home/fasano/git/avatar-qemu/hw/avatar/interrupts.c:58: undefined reference to `get_current_pc'
/home/fasano/git/avatar-qemu/hw/avatar/interrupts.c:63: undefined reference to `rmem_tx_queue_ref'
/home/fasano/git/avatar-qemu/hw/avatar/interrupts.c:63: undefined reference to `qemu_avatar_mq_send'
/home/fasano/git/avatar-qemu/hw/avatar/interrupts.c:64: undefined reference to `rmem_rx_queue_ref'
/home/fasano/git/avatar-qemu/hw/avatar/interrupts.c:64: undefined reference to `qemu_avatar_mq_receive'
```

Someone who knows how to use avatar-qemu should probably test the MIPS configurable machine before merging, I only made sure it compiled. Looks like a bunch of the QEMU APIs related to CPU creation changed ([here](https://github.com/qemu/qemu/commit/6063d4c0f98b35a27ca018393d328a1825412a7e)?).