### PR TITLE
Fix few bugs on the i386 target

### DIFF
--- a/hw/avatar/configurable_machine.c
+++ b/hw/avatar/configurable_machine.c
@@ -495,10 +495,7 @@ static THISCPU *create_cpu(MachineState * ms, QDict *conf)
     BusState* sysbus = sysbus_get_default();
     int num_irq = 64;
 
-#elif defined(TARGET_I386)
-    //
-
-#elif defined(TARGET_MIPS)
+#elif defined(TARGET_I386) || defined(TARGET_MIPS)
     Error *err = NULL;
 #endif  /* TARGET_ARM && ! TARGET_AARCH64 */
 
@@ -561,6 +558,19 @@ static THISCPU *create_cpu(MachineState * ms, QDict *conf)
     if (cpuu->apic_state) {
             device_legacy_reset(cpuu->apic_state);
     }
+
+    if (!object_property_set_uint(OBJECT(cpuu), "apic-id", 0, &err)) {
+        error_report_err(err);
+        object_unref(OBJECT(cpuu));
+        exit(EXIT_FAILURE);
+    }
+
+    if (!qdev_realize(DEVICE(cpuu), NULL, &err)) {
+        error_report_err(err);
+        object_unref(OBJECT(cpuu));
+        exit(EXIT_FAILURE);
+    }
+
 
 #elif defined(TARGET_MIPS)
     cpu_oc = cpu_class_by_name(TYPE_MIPS_CPU, cpu_type);

--- a/hw/avatar/meson.build
+++ b/hw/avatar/meson.build
@@ -17,7 +17,11 @@ specific_ss.add(when: ['CONFIG_AVATAR', 'TARGET_MIPS'], if_true: files(
   'avatar_posix.c',
   'remote_memory.c'
 ))
-specific_ss.add(when: ['CONFIG_AVATAR', 'TARGET_I386'], if_true: files('configurable_machine.c'))
+specific_ss.add(when: ['CONFIG_AVATAR', 'TARGET_I386'], if_true: files(
+  'configurable_machine.c',
+  'avatar_posix.c',
+  'remote_memory.c'
+))
 specific_ss.add(when: ['CONFIG_AVATAR', 'TARGET_X86_64'], if_true: files('configurable_machine.c'))
 specific_ss.add(when: ['CONFIG_AVATAR', 'TARGET_PPC'], if_true: files('configurable_machine.c'))
 

--- a/target/i386/cpu.c
+++ b/target/i386/cpu.c
@@ -5871,7 +5871,7 @@ static void x86_cpu_reset(DeviceState *dev)
       // of a unicorn-style execution
 
       // But do set hflags so we're in 32-bit mode (else we end up in 16-bit)
-      env->hflags |= HF_CS32_MASK;
+      env->hflags |= HF_CS32_MASK | HF_SS32_MASK;
       return;
     }else if (x86_configurable_machine_mode == 64) {
       // Set hflags so we're in 64-bit mode (else we end up in 16-bit)


### PR DESCRIPTION
This pull request aims at fixing two bugs when dealing with x86 targets.

The first one is related to the gdbstub complaining about the fact that the machine doesn't provide any CPU (as illustrated in this issue: https://github.com/avatartwo/avatar2/issues/110#issuecomment-1196950972). The fix involves plugging the CPU into the QOM hierarchy with `qdev_realize`.
Please note that a hardcoded apic-id is used at the moment which could prevent users from creating multiple CPUs on the target. However, I don't know if avatar-qemu could allow such possibility in any cases so I haven't dwelt on this issue.

The second bug is related to a wrong stack alignment when pushing and popping 32 bit values. This impedes the correct functioning of these instructions by preventing the value to be written in memory.
As qemu uses the CPU flag `HF_SS32_MASK` to retrieve the stack pointer size that is needed, the fix is to simply set it when initializing the CPU.

```c
// target/i386/tcg/translate.c

#define SS32(S)   (((S)->flags & HF_SS32_MASK) != 0)
// [...]
/* Select the size of the stack pointer.  */
static inline MemOp mo_stacksize(DisasContext *s)
{
    return CODE64(s) ? MO_64 : SS32(s) ? MO_32 : MO_16;
}
```

For the record, a third bug still remains on this target: the provided `entry_address` is not taken into account by the CPU and the execution instead starts from the beginning of the first ROM memory.
I tried to dig into that but without much success. Since this is an issue that can easily be circumvented directly from the python script, I've put it aside for now.