### PR TITLE
INTForwarder QEMU update

### DIFF
--- a/block/curl.c
+++ b/block/curl.c
@@ -498,8 +498,8 @@ static int curl_init_state(BDRVCURLState *s, CURLState *state)
          * Restricting protocols is only supported from 7.19.4 upwards.
          */
 #if LIBCURL_VERSION_NUM >= 0x071304
-        curl_easy_setopt(state->curl, CURLOPT_PROTOCOLS, PROTOCOLS);
-        curl_easy_setopt(state->curl, CURLOPT_REDIR_PROTOCOLS, PROTOCOLS);
+        curl_easy_setopt(state->curl, CURLOPT_PROTOCOLS_STR, PROTOCOLS);
+        curl_easy_setopt(state->curl, CURLOPT_REDIR_PROTOCOLS_STR, PROTOCOLS);
 #endif
 
 #ifdef DEBUG_VERBOSE
@@ -768,7 +768,7 @@ static int curl_open(BlockDriverState *bs, QDict *options, int flags,
     curl_easy_setopt(state->curl, CURLOPT_HEADERDATA, s);
     if (curl_easy_perform(state->curl))
         goto out;
-    if (curl_easy_getinfo(state->curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &d)) {
+    if (curl_easy_getinfo(state->curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &d)) {
         goto out;
     }
     /* Prior CURL 7.19.4 return value of 0 could mean that the file size is not

--- a/block/curl.c
+++ b/block/curl.c
@@ -37,8 +37,15 @@
 
 // #define DEBUG_VERBOSE
 
+/* CURL 7.85.0 switches to a string based API for specifying
+ * the desired protocols.
+ */
+#if LIBCURL_VERSION_NUM >= 0x075500
+#define PROTOCOLS "HTTP,HTTPS,FTP,FTPS"
+#else
 #define PROTOCOLS (CURLPROTO_HTTP | CURLPROTO_HTTPS | \
                    CURLPROTO_FTP | CURLPROTO_FTPS)
+#endif
 
 #define CURL_NUM_STATES 8
 #define CURL_NUM_ACB    8
@@ -508,9 +515,18 @@ static int curl_init_state(BDRVCURLState *s, CURLState *state)
          * obscure protocols.  For example, do not allow POP3/SMTP/IMAP see
          * CVE-2013-0249.
          *
-         * Restricting protocols is only supported from 7.19.4 upwards.
+         * Restricting protocols is only supported from 7.19.4 upwards. Note:
+         * version 7.85.0 deprecates CURLOPT_*PROTOCOLS in favour of a string
+         * based CURLOPT_*PROTOCOLS_STR API.
          */
-#if LIBCURL_VERSION_NUM >= 0x071304
+#if LIBCURL_VERSION_NUM >= 0x075500
+        if (curl_easy_setopt(state->curl,
+                             CURLOPT_PROTOCOLS_STR, PROTOCOLS) ||
+            curl_easy_setopt(state->curl,
+                             CURLOPT_REDIR_PROTOCOLS_STR, PROTOCOLS)) {
+            goto err;
+        }
+#elif LIBCURL_VERSION_NUM >= 0x071304
         if (curl_easy_setopt(state->curl, CURLOPT_PROTOCOLS, PROTOCOLS) ||
             curl_easy_setopt(state->curl, CURLOPT_REDIR_PROTOCOLS, PROTOCOLS)) {
             goto err;
@@ -668,7 +684,12 @@ static int curl_open(BlockDriverState *bs, QDict *options, int flags,
     const char *file;
     const char *cookie;
     const char *cookie_secret;
-    double d;
+    /* CURL >= 7.55.0 uses curl_off_t for content length instead of a double */
+#if LIBCURL_VERSION_NUM >= 0x073700
+    curl_off_t cl;
+#else
+    double cl;
+#endif
     const char *secretid;
     const char *protocol_delimiter;
     int ret;
@@ -793,27 +814,36 @@ static int curl_open(BlockDriverState *bs, QDict *options, int flags,
     }
     if (curl_easy_perform(state->curl))
         goto out;
-    if (curl_easy_getinfo(state->curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &d)) {
+    /* CURL 7.55.0 deprecates CURLINFO_CONTENT_LENGTH_DOWNLOAD in favour of
+     * the *_T version which returns a more sensible type for content length.
+     */
+#if LIBCURL_VERSION_NUM >= 0x073700
+    if (curl_easy_getinfo(state->curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &cl)) {
         goto out;
     }
+#else
+    if (curl_easy_getinfo(state->curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &cl)) {
+        goto out;
+    }
+#endif
     /* Prior CURL 7.19.4 return value of 0 could mean that the file size is not
      * know or the size is zero. From 7.19.4 CURL returns -1 if size is not
      * known and zero if it is really zero-length file. */
 #if LIBCURL_VERSION_NUM >= 0x071304
-    if (d < 0) {
+    if (cl < 0) {
         pstrcpy(state->errmsg, CURL_ERROR_SIZE,
                 "Server didn't report file size.");
         goto out;
     }
 #else
-    if (d <= 0) {
+    if (cl <= 0) {
         pstrcpy(state->errmsg, CURL_ERROR_SIZE,
                 "Unknown file size or zero-length file.");
         goto out;
     }
 #endif
 
-    s->len = d;
+    s->len = cl;
 
     if ((!strncasecmp(s->url, "http://", strlen("http://"))
         || !strncasecmp(s->url, "https://", strlen("https://")))

--- a/block/curl.c
+++ b/block/curl.c
@@ -498,8 +498,8 @@ static int curl_init_state(BDRVCURLState *s, CURLState *state)
          * Restricting protocols is only supported from 7.19.4 upwards.
          */
 #if LIBCURL_VERSION_NUM >= 0x071304
-        curl_easy_setopt(state->curl, CURLOPT_PROTOCOLS_STR, PROTOCOLS);
-        curl_easy_setopt(state->curl, CURLOPT_REDIR_PROTOCOLS_STR, PROTOCOLS);
+        curl_easy_setopt(state->curl, CURLOPT_PROTOCOLS, PROTOCOLS);
+        curl_easy_setopt(state->curl, CURLOPT_REDIR_PROTOCOLS, PROTOCOLS);
 #endif
 
 #ifdef DEBUG_VERBOSE
@@ -768,7 +768,7 @@ static int curl_open(BlockDriverState *bs, QDict *options, int flags,
     curl_easy_setopt(state->curl, CURLOPT_HEADERDATA, s);
     if (curl_easy_perform(state->curl))
         goto out;
-    if (curl_easy_getinfo(state->curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &d)) {
+    if (curl_easy_getinfo(state->curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &d)) {
         goto out;
     }
     /* Prior CURL 7.19.4 return value of 0 could mean that the file size is not

--- a/block/curl.c
+++ b/block/curl.c
@@ -457,38 +457,51 @@ static int curl_init_state(BDRVCURLState *s, CURLState *state)
         if (!state->curl) {
             return -EIO;
         }
-        curl_easy_setopt(state->curl, CURLOPT_URL, s->url);
-        curl_easy_setopt(state->curl, CURLOPT_SSL_VERIFYPEER,
-                         (long) s->sslverify);
-        curl_easy_setopt(state->curl, CURLOPT_SSL_VERIFYHOST,
-                         s->sslverify ? 2L : 0L);
-        if (s->cookie) {
-            curl_easy_setopt(state->curl, CURLOPT_COOKIE, s->cookie);
+        if (curl_easy_setopt(state->curl, CURLOPT_URL, s->url) ||
+            curl_easy_setopt(state->curl, CURLOPT_SSL_VERIFYPEER,
+                             (long) s->sslverify) ||
+            curl_easy_setopt(state->curl, CURLOPT_SSL_VERIFYHOST,
+                             s->sslverify ? 2L : 0L)) {
+            goto err;
         }
-        curl_easy_setopt(state->curl, CURLOPT_TIMEOUT, (long)s->timeout);
-        curl_easy_setopt(state->curl, CURLOPT_WRITEFUNCTION,
-                         (void *)curl_read_cb);
-        curl_easy_setopt(state->curl, CURLOPT_WRITEDATA, (void *)state);
-        curl_easy_setopt(state->curl, CURLOPT_PRIVATE, (void *)state);
-        curl_easy_setopt(state->curl, CURLOPT_AUTOREFERER, 1);
-        curl_easy_setopt(state->curl, CURLOPT_FOLLOWLOCATION, 1);
-        curl_easy_setopt(state->curl, CURLOPT_NOSIGNAL, 1);
-        curl_easy_setopt(state->curl, CURLOPT_ERRORBUFFER, state->errmsg);
-        curl_easy_setopt(state->curl, CURLOPT_FAILONERROR, 1);
-
+        if (s->cookie) {
+            if (curl_easy_setopt(state->curl, CURLOPT_COOKIE, s->cookie)) {
+                goto err;
+            }
+        }
+        if (curl_easy_setopt(state->curl, CURLOPT_TIMEOUT, (long)s->timeout) ||
+            curl_easy_setopt(state->curl, CURLOPT_WRITEFUNCTION,
+                             (void *)curl_read_cb) ||
+            curl_easy_setopt(state->curl, CURLOPT_WRITEDATA, (void *)state) ||
+            curl_easy_setopt(state->curl, CURLOPT_PRIVATE, (void *)state) ||
+            curl_easy_setopt(state->curl, CURLOPT_AUTOREFERER, 1) ||
+            curl_easy_setopt(state->curl, CURLOPT_FOLLOWLOCATION, 1) ||
+            curl_easy_setopt(state->curl, CURLOPT_NOSIGNAL, 1) ||
+            curl_easy_setopt(state->curl, CURLOPT_ERRORBUFFER, state->errmsg) ||
+            curl_easy_setopt(state->curl, CURLOPT_FAILONERROR, 1)) {
+            goto err;
+        }
         if (s->username) {
-            curl_easy_setopt(state->curl, CURLOPT_USERNAME, s->username);
+            if (curl_easy_setopt(state->curl, CURLOPT_USERNAME, s->username)) {
+                goto err;
+            }
         }
         if (s->password) {
-            curl_easy_setopt(state->curl, CURLOPT_PASSWORD, s->password);
+            if (curl_easy_setopt(state->curl, CURLOPT_PASSWORD, s->password)) {
+                goto err;
+            }
         }
         if (s->proxyusername) {
-            curl_easy_setopt(state->curl,
-                             CURLOPT_PROXYUSERNAME, s->proxyusername);
+            if (curl_easy_setopt(state->curl,
+                                 CURLOPT_PROXYUSERNAME, s->proxyusername)) {
+                goto err;
+            }
         }
         if (s->proxypassword) {
-            curl_easy_setopt(state->curl,
-                             CURLOPT_PROXYPASSWORD, s->proxypassword);
+            if (curl_easy_setopt(state->curl,
+                                 CURLOPT_PROXYPASSWORD, s->proxypassword)) {
+                goto err;
+            }
         }
 
         /* Restrict supported protocols to avoid security issues in the more
@@ -498,18 +511,27 @@ static int curl_init_state(BDRVCURLState *s, CURLState *state)
          * Restricting protocols is only supported from 7.19.4 upwards.
          */
 #if LIBCURL_VERSION_NUM >= 0x071304
-        curl_easy_setopt(state->curl, CURLOPT_PROTOCOLS, PROTOCOLS);
-        curl_easy_setopt(state->curl, CURLOPT_REDIR_PROTOCOLS, PROTOCOLS);
+        if (curl_easy_setopt(state->curl, CURLOPT_PROTOCOLS, PROTOCOLS) ||
+            curl_easy_setopt(state->curl, CURLOPT_REDIR_PROTOCOLS, PROTOCOLS)) {
+            goto err;
+        }
 #endif
 
 #ifdef DEBUG_VERBOSE
-        curl_easy_setopt(state->curl, CURLOPT_VERBOSE, 1);
+        if (curl_easy_setopt(state->curl, CURLOPT_VERBOSE, 1)) {
+            goto err;
+        }
 #endif
     }
 
     state->s = s;
 
     return 0;
+
+err:
+    curl_easy_cleanup(state->curl);
+    state->curl = NULL;
+    return -EIO;
 }
 
 /* Called with s->mutex held.  */
@@ -762,10 +784,13 @@ static int curl_open(BlockDriverState *bs, QDict *options, int flags,
     }
 
     s->accept_range = false;
-    curl_easy_setopt(state->curl, CURLOPT_NOBODY, 1);
-    curl_easy_setopt(state->curl, CURLOPT_HEADERFUNCTION,
-                     curl_header_cb);
-    curl_easy_setopt(state->curl, CURLOPT_HEADERDATA, s);
+    if (curl_easy_setopt(state->curl, CURLOPT_NOBODY, 1) ||
+        curl_easy_setopt(state->curl, CURLOPT_HEADERFUNCTION, curl_header_cb) ||
+        curl_easy_setopt(state->curl, CURLOPT_HEADERDATA, s)) {
+        pstrcpy(state->errmsg, CURL_ERROR_SIZE,
+                "curl library initialization failed.");
+        goto out;
+    }
     if (curl_easy_perform(state->curl))
         goto out;
     if (curl_easy_getinfo(state->curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &d)) {
@@ -878,9 +903,8 @@ static void curl_setup_preadv(BlockDriverState *bs, CURLAIOCB *acb)
 
     snprintf(state->range, 127, "%" PRIu64 "-%" PRIu64, start, end);
     trace_curl_setup_preadv(acb->bytes, start, state->range);
-    curl_easy_setopt(state->curl, CURLOPT_RANGE, state->range);
-
-    if (curl_multi_add_handle(s->multi, state->curl) != CURLM_OK) {
+    if (curl_easy_setopt(state->curl, CURLOPT_RANGE, state->range) ||
+        curl_multi_add_handle(s->multi, state->curl) != CURLM_OK) {
         state->acb[0] = NULL;
         acb->ret = -EIO;
 

--- a/gdb-xml/arm-m-profile.xml
+++ b/gdb-xml/arm-m-profile.xml
@@ -23,5 +23,5 @@
   <reg name="sp" bitsize="32" type="data_ptr"/>
   <reg name="lr" bitsize="32"/>
   <reg name="pc" bitsize="32" type="code_ptr"/>
-  <reg name="xPSR" bitsize="32" regnum="25"/>
+  <reg name="xpsr" bitsize="32" regnum="25"/>
 </feature>

--- a/gdb-xml/arm-m-profile.xml
+++ b/gdb-xml/arm-m-profile.xml
@@ -23,5 +23,5 @@
   <reg name="sp" bitsize="32" type="data_ptr"/>
   <reg name="lr" bitsize="32"/>
   <reg name="pc" bitsize="32" type="code_ptr"/>
-  <reg name="xpsr" bitsize="32" regnum="25"/>
+  <reg name="xPSR" bitsize="32" regnum="25"/>
 </feature>

--- a/hw/avatar/interrupts.c
+++ b/hw/avatar/interrupts.c
@@ -93,13 +93,6 @@ void qmp_avatar_armv7m_enable_irq(const char *irq_rx_queue_name,
 
     armv7m_exception_handling_enabled = true;
     qemu_log_mask(LOG_AVATAR, "armv7m interrupt injection enabled\n");
-
-    // Avatar2 Addition to enable interrupt injection, TODO(albrecht-flo): WIP refactor
-    ARMCPU *armcpu = ARM_CPU(qemu_get_cpu(0));
-    CPUARMState *env = &armcpu->env;
-    armv7m_nvic_enable_all_irqs(env->nvic);
-
-    qemu_log_mask(LOG_AVATAR, "armv7m interrupt injection enabled\n");
     qemu_log_flush();
 }
 
@@ -127,6 +120,8 @@ void qmp_avatar_armv7m_inject_irq(int64_t num_cpu,int64_t num_irq, Error **errp)
     qemu_log_mask(LOG_AVATAR, "Injecting exception 0x%lx\n", num_irq);
     ARMCPU *armcpu = ARM_CPU(qemu_get_cpu(num_cpu));
     CPUARMState *env = &armcpu->env;
+    // Ensure the interrupt is enabled
+    armv7m_nvic_enable_irq(env->nvic, num_irq);
     /*  MM: for now, we can only inject non-secure irqs */
     armv7m_nvic_set_pending(env->nvic, num_irq, false);
 }

--- a/hw/avatar/interrupts.c
+++ b/hw/avatar/interrupts.c
@@ -120,8 +120,6 @@ void qmp_avatar_armv7m_inject_irq(int64_t num_cpu,int64_t num_irq, Error **errp)
     qemu_log_mask(LOG_AVATAR, "Injecting exception 0x%lx\n", num_irq);
     ARMCPU *armcpu = ARM_CPU(qemu_get_cpu(num_cpu));
     CPUARMState *env = &armcpu->env;
-    // Ensure the interrupt is enabled
-    armv7m_nvic_enable_irq(env->nvic, num_irq);
     /*  MM: for now, we can only inject non-secure irqs */
     armv7m_nvic_set_pending(env->nvic, num_irq, false);
 }

--- a/hw/avatar/interrupts.c
+++ b/hw/avatar/interrupts.c
@@ -93,6 +93,13 @@ void qmp_avatar_armv7m_enable_irq(const char *irq_rx_queue_name,
 
     armv7m_exception_handling_enabled = true;
     qemu_log_mask(LOG_AVATAR, "armv7m interrupt injection enabled\n");
+
+    // Avatar2 Addition to enable interrupt injection, TODO(albrecht-flo): WIP refactor
+    ARMCPU *armcpu = ARM_CPU(qemu_get_cpu(0));
+    CPUARMState *env = &armcpu->env;
+    armv7m_nvic_enable_all_irqs(env->nvic);
+
+    qemu_log_mask(LOG_AVATAR, "armv7m interrupt injection enabled\n");
     qemu_log_flush();
 }
 

--- a/hw/i386/amd_iommu.c
+++ b/hw/i386/amd_iommu.c
@@ -911,7 +911,7 @@ static void amdvi_page_walk(AMDVIAddressSpace *as, uint64_t *dte,
         }
 
         /* we are at the leaf page table or page table encodes a huge page */
-        while (level > 0) {
+        do {
             pte_perms = amdvi_get_perms(pte);
             present = pte & 1;
             if (!present || perms != (perms & pte_perms)) {
@@ -930,10 +930,7 @@ static void amdvi_page_walk(AMDVIAddressSpace *as, uint64_t *dte,
             }
             oldlevel = level;
             level = get_pte_translation_mode(pte);
-            if (level == 0x7) {
-                break;
-            }
-        }
+        } while (level > 0 && level < 7);
 
         if (level == 0x7) {
             page_mask = pte_override_page_mask(pte);

--- a/hw/intc/armv7m_nvic.c
+++ b/hw/intc/armv7m_nvic.c
@@ -2364,7 +2364,9 @@ static MemTxResult nvic_sysreg_write(void *opaque, hwaddr addr,
     unsigned setval = 0;
 
 #ifdef CONFIG_AVATAR
-    avatar_armv7m_nvic_forward_write(offset, value, size);
+    if (avatar_armv7m_nvic_forward_write(offset, value, size)) {
+        goto exit_ok;
+    }
 #endif
     trace_nvic_sysreg_write(addr, value, size);
 

--- a/hw/intc/armv7m_nvic.c
+++ b/hw/intc/armv7m_nvic.c
@@ -2744,11 +2744,3 @@ static void armv7m_nvic_register_types(void)
 }
 
 type_init(armv7m_nvic_register_types)
-
-void armv7m_nvic_enable_irq(void* opaque, uint32_t irq) {
-    NVICState *s = (NVICState *)opaque;
-    assert(irq < s->num_irq);
-
-    VecInfo *vec = &s->vectors[irq];
-    vec->enabled = 1;
-}

--- a/hw/intc/armv7m_nvic.c
+++ b/hw/intc/armv7m_nvic.c
@@ -2745,13 +2745,10 @@ static void armv7m_nvic_register_types(void)
 
 type_init(armv7m_nvic_register_types)
 
-bool armv7m_nvic_enable_all_irqs(void* opaque) {
+void armv7m_nvic_enable_irq(void* opaque, uint32_t irq) {
     NVICState *s = (NVICState *)opaque;
+    assert(irq < s->num_irq);
 
-    for (int i = 1; i < s->num_irq; ++i) {
-        VecInfo *vec = &s->vectors[i];
-        vec->enabled = 1;
-    }
-
-    return true;
+    VecInfo *vec = &s->vectors[irq];
+    vec->enabled = 1;
 }

--- a/hw/intc/armv7m_nvic.c
+++ b/hw/intc/armv7m_nvic.c
@@ -2744,3 +2744,14 @@ static void armv7m_nvic_register_types(void)
 }
 
 type_init(armv7m_nvic_register_types)
+
+bool armv7m_nvic_enable_all_irqs(void* opaque) {
+    NVICState *s = (NVICState *)opaque;
+
+    for (int i = 1; i < s->num_irq; ++i) {
+        VecInfo *vec = &s->vectors[i];
+        vec->enabled = 1;
+    }
+
+    return true;
+}

--- a/include/hw/avatar/interrupts.h
+++ b/include/hw/avatar/interrupts.h
@@ -21,6 +21,6 @@ typedef struct V7MInterruptResp{
 
 void avatar_armv7m_exception_exit(int irq, uint32_t type);
 void avatar_armv7m_exception_enter(int irq);
-void avatar_armv7m_nvic_forward_write(uint32_t offset, uint32_t value,unsigned size);
+bool avatar_armv7m_nvic_forward_write(uint32_t offset, uint32_t value,unsigned size);
 
 #endif

--- a/qapi-schema.json
+++ b/qapi-schema.json
@@ -6382,8 +6382,8 @@
 ##
 { 'command': 'avatar-armv7m-enable-irq',
   'data': {
-      'irq_rx_queue_name': 'str', 'irq_tx_queue_name': 'str',
-      'rmem_rx_queue_name': 'str', 'rmem_tx_queue_name': 'str'
+      'irq-rx-queue-name': 'str', 'irq-tx-queue-name': 'str',
+      'rmem-rx-queue-name': 'str', 'rmem-tx-queue-name': 'str'
   }
 }
 
@@ -6404,7 +6404,7 @@
 # avatar-qemu only
 ##
 { 'command': 'avatar-armv7m-inject-irq',
-  'data': {'num_cpu': 'int', 'num_irq': 'int' }
+  'data': {'num-cpu': 'int', 'num-irq': 'int' }
 }
 
 ##
@@ -6415,7 +6415,7 @@
 # avatar-qemu only
 ##
 { 'command': 'avatar-armv7m-ignore-irq-return',
-  'data': {'num_irq': 'int' }
+  'data': {'num-irq': 'int' }
 }
 
 
@@ -6427,7 +6427,7 @@
 # avatar-qemu only
 ##
 { 'command': 'avatar-armv7m-unignore-irq-return',
-  'data': {'num_irq': 'int' }
+  'data': {'num-irq': 'int' }
 }
 
 
@@ -6439,7 +6439,7 @@
 # avatar-qemu only
 ##
 { 'command': 'avatar-armv7m-set-vector-table-base',
-  'data': {'num_cpu': 'int', 'base': 'int' }
+  'data': {'num-cpu': 'int', 'base': 'int' }
 }
 
 

--- a/qobject/block-qdict.c
+++ b/qobject/block-qdict.c
@@ -251,12 +251,12 @@ void qdict_array_split(QDict *src, QList **dst)
         if (is_subqdict) {
             qdict_extract_subqdict(src, &subqdict, prefix);
             assert(qdict_size(subqdict) > 0);
+            qlist_append_obj(*dst, QOBJECT(subqdict));
         } else {
             qobject_ref(subqobj);
             qdict_del(src, indexstr);
+            qlist_append_obj(*dst, subqobj);
         }
-
-        qlist_append_obj(*dst, subqobj ?: QOBJECT(subqdict));
     }
 }
 

--- a/softmmu/physmem.c
+++ b/softmmu/physmem.c
@@ -3440,8 +3440,14 @@ int cpu_memory_rw_debug(CPUState *cpu, target_ulong addr,
             l = len;
         phys_addr += (addr & ~TARGET_PAGE_MASK);
         if (is_write) {
-            res = address_space_write_rom(cpu->cpu_ases[asidx].as, phys_addr,
+            if (memory_region_is_rom(cpu->cpu_ases[asidx].as->root)) {
+                res = address_space_write_rom(cpu->cpu_ases[asidx].as, phys_addr,
+                                              attrs, buf, l);
+            } else {
+                /* Use address space write to make sure callbacks on the MMIO are triggered when writing to RAM */
+                res = address_space_write(cpu->cpu_ases[asidx].as, phys_addr,
                                           attrs, buf, l);
+            }
         } else {
             res = address_space_read(cpu->cpu_ases[asidx].as, phys_addr,
                                      attrs, buf, l);

--- a/target/arm/cpu.h
+++ b/target/arm/cpu.h
@@ -2335,6 +2335,10 @@ static inline bool armv7m_nvic_can_take_pending_exception(void *opaque)
     return true;
 }
 #endif
+
+// Avatar2 Addition to enable interrupt injection, TODO(albrecht-flo): WIP refactor
+bool armv7m_nvic_enable_all_irqs(void *opaque);
+
 /**
  * armv7m_nvic_set_pending: mark the specified exception as pending
  * @opaque: the NVIC

--- a/target/arm/cpu.h
+++ b/target/arm/cpu.h
@@ -2336,9 +2336,6 @@ static inline bool armv7m_nvic_can_take_pending_exception(void *opaque)
 }
 #endif
 
-// Avatar2 Addition to enable interrupt injection, TODO(albrecht-flo): WIP refactor
-void armv7m_nvic_enable_irq(void *opaque, uint32_t irq);
-
 /**
  * armv7m_nvic_set_pending: mark the specified exception as pending
  * @opaque: the NVIC

--- a/target/arm/cpu.h
+++ b/target/arm/cpu.h
@@ -2337,7 +2337,7 @@ static inline bool armv7m_nvic_can_take_pending_exception(void *opaque)
 #endif
 
 // Avatar2 Addition to enable interrupt injection, TODO(albrecht-flo): WIP refactor
-bool armv7m_nvic_enable_all_irqs(void *opaque);
+void armv7m_nvic_enable_irq(void *opaque, uint32_t irq);
 
 /**
  * armv7m_nvic_set_pending: mark the specified exception as pending


### PR DESCRIPTION
Includes
* Merges [block-qdict: Fix -Werror=maybe-uninitialized build failure](https://github.com/avatartwo/avatar-qemu/pull/13/commits/1be57de0db11d0b68c77071bf8115c0dcc45d434)
* Merges [hw/i386/amd_iommu: Fix maybe-uninitialized error with GCC 12](https://github.com/avatartwo/avatar-qemu/commit/b4fe8354f68d3c7e1dd4578582029d2fc978165f)
* Fixes QMP commands for interrupt orchestration
* Allows for NVIC register writes to be dropped by the orchestrator
* Fixes GDB memory writes not triggering MMIO callbacks